### PR TITLE
add region support

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -37,8 +37,8 @@ module.exports = class Adapter {
           { service:
             { accessKeyId: opts.key || defaults.service.accessKeyId
             , secretAccessKey: opts.secret || defaults.service.secretAccessKey
-            , apiVersion: '2006-03-01',
-              region: opts.region || defaults.service.region
+            , apiVersion: '2006-03-01'
+            , region: opts.region || defaults.service.region
             }
 
           , request:

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -37,7 +37,8 @@ module.exports = class Adapter {
           { service:
             { accessKeyId: opts.key || defaults.service.accessKeyId
             , secretAccessKey: opts.secret || defaults.service.secretAccessKey
-            , apiVersion: '2006-03-01'
+            , apiVersion: '2006-03-01',
+              region: opts.region || defaults.service.region
             }
 
           , request:

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -49,6 +49,8 @@ module.exports = class Uploader extends WritableStream {
                    .into({})
 
         , request = scope.client.upload(params, scope.opts.options, (err, data) => {
+          if (err)
+            return done(err)
           // Attach the response data to the stream - Skipper packages this in its response to the
           // caller for further reuse
           inStream.extra = data


### PR DESCRIPTION
Specifying a region is essential if you are using any region other than us-standard. This PR allows you to specify a region while initializing the adapter.

Sample usage:

``` javascript
req.file('file')
    .upload({
        adapter: require('skipper-better-s3')({ region: 'YOUR_REGION' }),
        key: YOUR_KEY,
        bucket: YOUR_BUCKET,
        // ...
      }, function fileUploadComplete (err, uploadedFiles) {
        if (err) {
          return res.serverError(err);
        }
        return res.ok('File upload complete!');
      })
```
