### PR TITLE
Allow endpoint-related configs

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -37,7 +37,11 @@ module.exports = class Adapter {
         accessKeyId: opts.key || defaults.service.accessKeyId,
         secretAccessKey: opts.secret || defaults.service.secretAccessKey,
         apiVersion: '2006-03-01',
-        region: opts.region || defaults.service.region
+        region: opts.region || defaults.service.region,
+        sslEnabled: opts.sslEnabled || defaults.service.sslEnabled,
+        endpoint: opts.endpoint || defaults.service.endpoint,
+        s3BucketEndpoint: opts.s3BucketEndpoint || defaults.service.s3BucketEndpoint,
+        s3ForcePathStyle: opts.s3ForcePathStyle || defaults.service.s3ForcePathStyle
       },
 
       request: {


### PR DESCRIPTION
Allows the developer to chose how the constructor should be built. 

Use cases: 
- Buckets under custom DNS (http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html)
- Testing with tools like [s3rver](https://github.com/jamhall/s3rver)

example config with _s3rver_:

``` js
const options = { 
  adapter: require('skipper-better-s3'),
  key: 'somekeyhere',
  secret: 'dontsharethis',
  bucket: 'my-s3-bucket',
  sslEnabled: false,
  endpoint: 'http://localhost:4568',
  s3BucketEndpoint: false,
  s3ForcePathStyle: true
};

req.file('avatar').upload(options, (err, files) => {
  // ... Continue as usual
});
```
