### PR TITLE
Fix node-uuid deprecation warning

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -13,7 +13,7 @@ const path = require('path')
 const AWS = require('aws-sdk')
 const mime = require('mime')
 const merge = require('semantic-merge')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const local = require('local-scope')()
 const Hasher = require('./hasher')
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "aws-sdk": "^2.2.46",
     "local-scope": "^1.0.0",
     "mime": "^1.3.4",
-    "node-uuid": "^1.4.3",
-    "semantic-merge": "^2.0.0"
+    "semantic-merge": "^2.0.0",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "@strv/eslint-config-javascript": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skipper-better-s3",
   "description": "A better approach to Amazon S3 file management for Skipper",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Robert Rossmann",
     "email": "rr.rossmann@me.com"


### PR DESCRIPTION
`node-uuid` package is deprecated in favor of the `uuid` package:
https://github.com/kelektiv/node-uuid/issues/155