### PR TITLE
Fix s3params override of object Key

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -57,11 +57,11 @@ module.exports = class Uploader extends WritableStream {
     const type = mime.lookup(name)
     const outStream = new Hasher()
     const params = merge({
-      Key: fd,
       Body: outStream,
       ContentType: type
-    }).and(scope.opts.request)
-      .excluding('onProgress')
+    }).and(scope.opts.request).and({
+      Key: fd
+    }).excluding('onProgress')
       .into({})
 
     const request = scope.client.upload(params, scope.opts.options, (err, data) => {


### PR DESCRIPTION
s3params.Key was not properly being merged into S3.upload params object. Caused by incorrect order of objects being merged via semantic-merge.